### PR TITLE
Backup restore initialization and deleteSong queue conflicts

### DIFF
--- a/lib/screens/settings/backup_storage/cubit/backup_storage_cubit.dart
+++ b/lib/screens/settings/backup_storage/cubit/backup_storage_cubit.dart
@@ -14,6 +14,8 @@ part 'backup_storage_state.dart';
 class BackupStorageCubit extends Cubit<BackupStorageState> {
   final SettingsManager _settingsManager = GetIt.I<SettingsManager>();
   final FileStorage _fileStorage = GetIt.I<FileStorage>();
+  final DownloadManager _downloadsManager = GetIt.I<DownloadManager>();
+  final LibraryService _library = GetIt.I<LibraryService>();
 
   late final VoidCallback _listener;
 
@@ -45,6 +47,10 @@ class BackupStorageCubit extends Cubit<BackupStorageState> {
 
   Future<void> restore() async {
     final success = await _fileStorage.loadBackup();
+    if (success) {
+      await _downloadsManager.reInit();
+      await _library.reInit();
+    }
     emit(
       state.copyWith(
         lastResult: success ? const RestoreSuccess() : const RestoreFailure(),

--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -423,11 +423,18 @@ class DownloadManager {
     Map? song = _box.get(key);
     final Map playlists = song?['playlists'];
     if (song != null && (playlists.keys.contains(playlistId))) {
-      if (playlists.length == 1) {
+      song['playlists'].remove(playlistId);
+      if (song['playlists'].isEmpty) {
         await _deleteSongInstance(song);
       } else {
-        // Remove playlist from Song Instance
-        song['playlists'].remove(playlistId);
+        if (song['status'] == "QUEUED") {
+          for (var item in _downloadQueue) {
+            if (item['videoId'] == song['videoId']) {
+              item['playlists'] = playlists;
+              break;
+            }
+          }
+        }
         await _box.put(key, song);
       }
     }
@@ -437,7 +444,7 @@ class DownloadManager {
   Future<void> deleteAllSongs() async {
     List<Map> songs = _box.values.toList().cast<Map>();
     for (Map song in songs) {
-      _deleteSongInstance(song);
+      await _deleteSongInstance(song);
     }
   }
 

--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -70,6 +70,11 @@ class DownloadManager {
     });
   }
 
+  Future<void> reInit() async {
+    await _cleanAndMigrateData();
+    await _refreshData();
+  }
+
   static Future<DownloadManager> create() async {
     final boxName = 'DOWNLOADS';
     await Hive.openBox(boxName);

--- a/lib/services/library.dart
+++ b/lib/services/library.dart
@@ -33,6 +33,12 @@ class LibraryService extends ChangeNotifier {
   );
   Map? getPlaylist(String playlistId) => _box.get(playlistId);
 
+  Future<void> reInit() async {
+    await _migrateLibIcons();
+    _playlists = _box.toMap();
+    notifyListeners();
+  }
+
   Future<void> _migrateLibIcons() async {
     for (final entry in userPlaylists.entries) {
       final id = entry.key;


### PR DESCRIPTION
This PR addresses two separate issues:
- Added a re-initialization step after the restore process. This prevents issues when loading a backup from an older version of the app, ensuring that all necessary data migration operations are properly triggered.
- Fixed a bug in deleteSong to handle conflicts when deleting a song from a playlist while it is still in the download queue for another playlist.