### PR TITLE
Add Spotify playlist import tool (CSV/txt → Favourites via Backup & Restore)

### DIFF
--- a/docs-spotify-import/SPOTIFY_IMPORT.md
+++ b/docs-spotify-import/SPOTIFY_IMPORT.md
@@ -1,0 +1,145 @@
+# Importing a Spotify Playlist into Gyawun Music (Android)
+
+Gyawun streams from YouTube Music and has no direct Spotify connection, so
+there's no built-in "Connect Spotify" button. This guide walks through a
+one-time workaround: export your Spotify playlist, match it against YouTube
+Music, and bulk-import the result into your **Favourites** using Gyawun's
+existing Backup & Restore feature.
+
+This uses a small helper script at [`tool/spotify_import`](../tool/spotify_import),
+run once on a computer. It does **not** require modifying the app or your
+phone in any special way — you're just generating a JSON file the app
+already knows how to read.
+
+**Estimated time:** 10-20 minutes for a large playlist (500+ songs), mostly
+unattended.
+
+---
+
+## Overview
+
+1. Export your Spotify playlist to a file (on any computer, via a website)
+2. Run the import script (on the same computer) — it searches YouTube Music
+   for each track and builds a `Backup & Restore` JSON file
+3. Move that JSON file to your Android phone
+4. Restore it inside Gyawun Music
+
+---
+
+## Step 1 — Export your Spotify playlist
+
+The easiest way, no Spotify developer account needed:
+
+1. On a computer, go to **[exportify.net](https://exportify.net)** 
+or **[Tune My Music](https://www.tunemymusic.com/)**
+or **[Sound Biz](https://soundiiz.com/)**
+2. Log in with your Spotify account (Exportify only reads your playlists —
+   it doesn't modify anything)
+3. Find the playlist you want to import, click to export it
+4. You'll get a `.csv` file (e.g. `Liked Songs.csv`) — save it somewhere
+   you'll remember
+
+*(Alternative: if you already have a plain list of songs, save it as a
+`.txt` file with one song per line, formatted as `Artist - Title`. The
+script supports both formats.)*
+
+---
+
+## Step 2 — Set up Python (one-time)
+
+You need Python on the same computer:
+
+- **Windows:** install from [python.org/downloads](https://python.org/downloads).
+  Check **"Add Python to PATH"** during setup.
+- **Mac:** usually preinstalled — check with `python3 --version` in Terminal.
+- **Linux:** almost certainly already installed.
+
+---
+
+## Step 3 — Get the script and install its one dependency
+
+If you've cloned the Gyawun repo, the script is at `tool/spotify_import/`.
+Otherwise, download `import_spotify_to_gyawun.py` and `requirements.txt`
+from that folder in the repo.
+
+Open a terminal in that folder and run:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Step 4 — Run the import
+
+```bash
+python import_spotify_to_gyawun.py "Liked Songs.csv" gyawun_favourites_backup.json
+```
+
+Replace `"Liked Songs.csv"` with your exported file (use the `.txt` file
+instead if that's what you have). The second argument is just the name
+you want the output file to have.
+
+You'll see one line printed per track as it's matched:
+
+```
+[1/620] OK  PALMITO - La Cuarta Estrella  ->  PALMITO - La Cuarta Estrella
+[2/620] OK  Mariah Carey - Fantasy  ->  Mariah Carey - Fantasy
+[3/620] MISS  Some Obscure Local Release
+```
+
+When it finishes, you'll have `gyawun_favourites_backup.json` in that
+folder. Tracks it couldn't confidently match are listed in a companion
+`gyawun_favourites_backup.json.notfound.txt` file — worth a quick manual
+check afterward, since matching is by search, not exact ID.
+
+> Large playlists take a while — the script deliberately paces its
+> requests to avoid hammering YouTube Music's search.
+
+---
+
+## Step 5 — Move the JSON file to your Android phone
+
+Any of these work:
+
+- Email it to yourself and open the attachment on your phone
+- Upload to Google Drive / Dropbox, then open the Drive/Dropbox app on your phone
+- Plug the phone into the computer via USB and copy the file over
+- Use `adb push gyawun_favourites_backup.json /sdcard/Download/` if you
+  have `adb` set up
+
+Either way, make sure it ends up somewhere your phone's file picker can
+browse to (Downloads folder is simplest).
+
+---
+
+## Step 6 — Restore it in Gyawun Music
+
+1. Open Gyawun Music on your phone
+2. Go to **Settings → Backup and Restore**
+3. Tap **Restore**
+4. Browse to and select `gyawun_favourites_backup.json`
+5. Matched tracks will appear in your **Favourites**
+
+---
+
+## Optional — Download everything for offline listening
+
+Once restored, you can queue every song for offline download in one action:
+
+1. Open your **Favourites** page
+2. Tap the **⋮ (more)** icon near the top
+3. Tap **Download**
+
+This queues the whole list, not one song at a time. Do this on Wi-Fi if
+your playlist is large — it adds up in storage and data.
+
+---
+
+## Troubleshooting
+
+| Problem | Likely cause |
+|---|---|
+| Lots of `MISS` results | Track names with unusual formatting, regional/local releases not on YouTube Music, or a network hiccup — try re-running just the `.notfound.txt` entries |
+| Wrong song matched | Search-based matching isn't perfect for common titles/remixes — check `.notfound.txt`-adjacent mismatches manually and re-add via in-app search if needed |
+| Restore does nothing / errors | Confirm the JSON file wasn't modified/corrupted in transit (re-copy it), and that you're picking the `.json` file, not the `.csv`/`.txt` source |

--- a/tool-spotify-import/import_spotify_to_gyawun.py
+++ b/tool-spotify-import/import_spotify_to_gyawun.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Import a Spotify playlist into Gyawun Music by generating a
+Backup & Restore JSON file the app can import directly into Favourites.
+
+WHY THIS EXISTS
+----------------
+Gyawun has no direct Spotify integration (it's a YouTube Music client),
+so there's no 1-click "connect Spotify" flow. This script bridges the gap:
+it takes a list of your Spotify tracks, finds each one on YouTube Music,
+and produces a JSON file matching Gyawun's Backup & Restore format:
+
+    {
+      "name": "Gyawun",
+      "type": "backup",
+      "version": 1,
+      "data": { "favourites": { "<videoId>": { ...song fields... }, ... } }
+    }
+
+Settings > Backup and Restore > Restore in the app then merges that
+straight into your Favourites - no manual searching/tapping per song.
+
+SUPPORTED INPUT FORMATS
+------------------------
+1. Exportify CSV (https://exportify.net) - export any Spotify playlist
+   without needing a developer account. Recommended for most users.
+   Expected columns include "Track Name" and "Artist Name(s)"
+   (Exportify's default export header names).
+
+2. Plain text, one track per line, formatted as:
+       Artist - Track Title
+   Useful if you already have a list from elsewhere.
+
+Format is auto-detected from the file extension (.csv vs .txt).
+
+SETUP
+-----
+    pip install ytmusicapi
+
+USAGE
+-----
+    python import_spotify_to_gyawun.py playlist.csv gyawun_favourites_backup.json
+    python import_spotify_to_gyawun.py playlist.txt gyawun_favourites_backup.json
+
+Then on your phone:
+    1. Get the output .json file onto the device (email, cloud drive, USB...)
+    2. Open Gyawun Music -> Settings -> Backup and Restore -> Restore
+    3. Select the JSON file.
+
+A companion "<output>.notfound.txt" lists any tracks that couldn't be
+confidently matched, so they can be checked by hand.
+"""
+
+import csv
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+from ytmusicapi import YTMusic
+
+
+def clean_query(text: str) -> str:
+    """Strip parenthetical noise like (feat. X) / (with X) that can
+    confuse search matching, while keeping the core artist/title."""
+    cleaned = re.sub(r"\s*\((?:with|feat\.?|ft\.?)[^)]*\)", "", text, flags=re.I)
+    return cleaned.strip()
+
+
+def load_tracks(input_path: Path):
+    """Returns a list of (artist, title, raw_label) tuples from either
+    an Exportify CSV export or a plain 'Artist - Title' text file."""
+    if input_path.suffix.lower() == ".csv":
+        return _load_csv(input_path)
+    return _load_txt(input_path)
+
+
+def _load_csv(input_path: Path):
+    tracks = []
+    with input_path.open(newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        # Exportify's default headers; fall back gracefully if renamed/lowercased.
+        field_map = {k.strip().lower(): k for k in (reader.fieldnames or [])}
+        title_key = field_map.get("track name") or field_map.get("name")
+        artist_key = field_map.get("artist name(s)") or field_map.get("artist")
+        if not title_key or not artist_key:
+            raise ValueError(
+                "Couldn't find 'Track Name' / 'Artist Name(s)' columns in the CSV. "
+                "Make sure this is an Exportify export, or use the .txt format instead."
+            )
+        for row in reader:
+            title = (row.get(title_key) or "").strip()
+            artist = (row.get(artist_key) or "").split(",")[0].strip()  # first listed artist
+            if title:
+                tracks.append((artist or None, title, f"{artist} - {title}".strip(" -")))
+    return tracks
+
+
+def _load_txt(input_path: Path):
+    tracks = []
+    for line in input_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(" - ", 1)
+        if len(parts) == 2:
+            tracks.append((parts[0].strip(), parts[1].strip(), line))
+        else:
+            tracks.append((None, line, line))
+    return tracks
+
+
+def build_song_entry(result: dict, created_at: int) -> dict:
+    return {
+        "videoId": result.get("videoId"),
+        "title": result.get("title"),
+        "artists": result.get("artists") or [],
+        "album": result.get("album"),
+        "thumbnails": result.get("thumbnails") or [],
+        "explicit": bool(result.get("isExplicit", False)),
+        "duration": result.get("duration"),
+        "duration_seconds": result.get("duration_seconds"),
+        "createdAt": created_at,
+    }
+
+
+def search_best_match(yt: YTMusic, artist, title, raw_label):
+    """Try a few query strategies, return the best 'songs' result."""
+    queries = []
+    if artist:
+        queries.append(f"{artist} {title}")
+    queries.append(clean_query(raw_label))
+    queries.append(raw_label)
+
+    seen = set()
+    for q in queries:
+        if not q or q in seen:
+            continue
+        seen.add(q)
+        try:
+            results = yt.search(q, filter="songs", limit=5)
+        except Exception:
+            results = []
+        if results:
+            return results[0]
+    return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python import_spotify_to_gyawun.py <playlist.csv|playlist.txt> [output.json]")
+        sys.exit(1)
+
+    input_path = Path(sys.argv[1])
+    output_path = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("gyawun_favourites_backup.json")
+    notfound_path = output_path.with_suffix(output_path.suffix + ".notfound.txt")
+
+    tracks = load_tracks(input_path)
+    print(f"Loaded {len(tracks)} tracks from {input_path}")
+
+    yt = YTMusic()  # no auth needed for search
+
+    favourites = {}
+    not_found = []
+    base_time = int(time.time() * 1000)
+
+    for i, (artist, title, raw_label) in enumerate(tracks, start=1):
+        match = search_best_match(yt, artist, title, raw_label)
+
+        if match and match.get("videoId"):
+            vid = match["videoId"]
+            if vid in favourites:
+                print(f"[{i}/{len(tracks)}] (dup) {raw_label}")
+            else:
+                favourites[vid] = build_song_entry(match, base_time + i)
+                matched_title = match.get("title")
+                matched_artist = ", ".join(a["name"] for a in (match.get("artists") or []))
+                print(f"[{i}/{len(tracks)}] OK  {raw_label}  ->  {matched_artist} - {matched_title}")
+        else:
+            not_found.append(raw_label)
+            print(f"[{i}/{len(tracks)}] MISS {raw_label}")
+
+        time.sleep(0.25)  # be polite to the (unauthenticated) API
+
+    backup = {
+        "name": "Gyawun",
+        "type": "backup",
+        "version": 1,
+        "data": {"favourites": favourites},
+    }
+    output_path.write_text(json.dumps(backup), encoding="utf-8")
+
+    if not_found:
+        notfound_path.write_text("\n".join(not_found), encoding="utf-8")
+
+    print()
+    print(f"Matched {len(favourites)}/{len(tracks)} tracks.")
+    print(f"Backup file written to: {output_path}")
+    if not_found:
+        print(f"{len(not_found)} unmatched tracks written to: {notfound_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tool-spotify-import/requirements.txt
+++ b/tool-spotify-import/requirements.txt
@@ -1,0 +1,1 @@
+ytmusicapi>=1.0.0


### PR DESCRIPTION
## What this does

Adds a standalone Python script (`tool/spotify_import/import_spotify_to_gyawun.py`)
that lets users bulk-import a Spotify playlist into their Gyawun Favourites,
plus a step-by-step guide (`docs/SPOTIFY_IMPORT.md`) for running it.

The script:
- Accepts either an Exportify CSV export (exportify.net) or a plain
  `Artist - Title` text list
- Searches YouTube Music (via `ytmusicapi`) for each track and takes the
  best "song" match
- Writes a JSON file in Gyawun's existing Backup & Restore format
  (`{"name": "Gyawun", "type": "backup", "data": {"favourites": {...}}}`)
- Logs unmatched tracks to a companion `.notfound.txt` file for manual review

Users then import the generated JSON through the app's existing
**Settings → Backup and Restore → Restore** flow — no new app code or UI
required.

## Why

Gyawun has no Spotify integration and no bulk-add path for Favourites, so
migrating an existing Spotify library means manually searching and adding
every song by hand. This script automates that using functionality the
app already has (Backup & Restore), rather than adding new in-app surface
area.

## User-facing changes

None to the app itself — this is a standalone tool + docs addition. No
Dart/Flutter code touched, no new app dependencies.

## New dependency

`ytmusicapi` (Python), scoped to this tool only (`tool/spotify_import/requirements.txt`) —
not a dependency of the Flutter app.

## Testing

Ran locally against a 620-track playlist; matched the large majority of
tracks correctly, with expected misses on obscure/regional releases not
present on YouTube Music (logged to `.notfound.txt` as designed).

## Files added
- `tool/spotify_import/import_spotify_to_gyawun.py`
- `tool/spotify_import/requirements.txt`
- `docs/SPOTIFY_IMPORT.md`